### PR TITLE
Expose Query functionality for the SDK to use

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -5,10 +5,11 @@ package config
 
 import (
 	"fmt"
-	"github.com/jmespath/go-jmespath"
-	"github.com/microsoft/moc/pkg/marshal"
 	"io/ioutil"
 	"reflect"
+
+	"github.com/jmespath/go-jmespath"
+	"github.com/microsoft/moc/pkg/marshal"
 )
 
 // Load the virtual machine configuration from the specified path
@@ -117,7 +118,7 @@ func LoadValueFile(path string) (*string, error) {
 func ExportFormatList(datasets interface{}, path string, query string, outputType string) error {
 	var fileToWrite string
 
-	marshaledByte, err := marshalOutput(datasets, query, outputType)
+	marshaledByte, err := MarshalOutput(datasets, query, outputType)
 	if err != nil {
 		fmt.Printf("%v", err)
 		return err
@@ -132,7 +133,7 @@ func ExportFormatList(datasets interface{}, path string, query string, outputTyp
 }
 
 func PrintFormat(data interface{}, query string, outputType string) {
-	marshaledByte, err := marshalOutput(data, query, outputType)
+	marshaledByte, err := MarshalOutput(data, query, outputType)
 	if err != nil {
 		fmt.Printf("%v", err)
 		return
@@ -144,7 +145,7 @@ func PrintFormatList(datasets interface{}, query string, outputType string) {
 	PrintFormat(datasets, query, outputType)
 }
 
-func marshalOutput(data interface{}, query string, outputType string) ([]byte, error) {
+func MarshalOutput(data interface{}, query string, outputType string) ([]byte, error) {
 	var queryTarget interface{}
 	var result interface{}
 	var err error
@@ -154,7 +155,6 @@ func marshalOutput(data interface{}, query string, outputType string) ([]byte, e
 		return nil, err
 	}
 	marshal.FromJSONBytes(jsonByte, &queryTarget)
-
 	if query != "" {
 		result, err = jmespath.Search(query, queryTarget)
 		if err != nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -2,7 +2,12 @@
 // Licensed under the Apache v2.0 license.
 package config
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+
+	"github.com/microsoft/moc/pkg/marshal"
+)
 
 type SampleStruct struct {
 	TestString  string   `json:"testString,omitempty" yaml:testString,omitempty"`
@@ -74,4 +79,44 @@ func Test_PrintFormat(t *testing.T) {
 func Test_PrintFormatList(t *testing.T) {
 	PrintFormatList(tmpArray, "", "tsv")
 	PrintFormatList(tmpArray, "", "csv")
+}
+
+func Test_MarshalOutputWithoutQuery(t *testing.T) {
+	err := verifyMarshalOutput(tmpArray, "", 2)
+	if err != nil {
+		t.Errorf("MarshalOutput with empty query failed: %s", err.Error())
+	}
+}
+
+func Test_MarshalOutputWithIntQuery(t *testing.T) {
+	err := verifyMarshalOutput(tmpArray, "[?testInt==`2`]", 1)
+	if err != nil {
+		t.Errorf("MarshalOutput with int query failed: %s", err.Error())
+	}
+}
+
+func Test_MarshalOutputWithStringQuery(t *testing.T) {
+	err := verifyMarshalOutput(tmpArray, "[?testString=='test1String']", 1)
+	if err != nil {
+		t.Errorf("MarshalOutput with string query failed: %s", err.Error())
+	}
+}
+
+func verifyMarshalOutput(data interface{}, query string, expectedResultCount int) error {
+	result, err := MarshalOutput(data, query, "json")
+	if err != nil {
+		return err
+	}
+
+	var filteredArray []SampleStruct
+	err = marshal.FromJSONBytes(result, &filteredArray)
+	if err != nil {
+		return err
+	}
+
+	if len(filteredArray) != expectedResultCount {
+		return fmt.Errorf("Unexpected result count. Expected: %d / Actual: %d", expectedResultCount, len(filteredArray))
+	}
+
+	return nil
 }


### PR DESCRIPTION
We need to allow SDK callers such as CSI, MOC Cloud Provider, etc to be able to query cloudagent entities by arbitrary properties. For example, we should be able to 'get' VM's by computername or vmsize etc. 

MOC already exposes a nice query functionality that the CTL uses today. This change just updates MOC to expose it's  existing query logic so that the moc-sdk-for-go can use it too (and adds tests for it). There is a separate PR for moc-sdk-for-go which updates the SDK to expose a Query function from computer.VirtualMachine that uses this updated moc code.

End experience would be for a moc-sdk-for-go caller to be able to do something like the following to get VMs by vmsize:

`vmclient.Query(ctx, group, "[?virtualmachineproperties.hardwareprofile.vmsize=='Standard_A4_v2']")
`