### PR TITLE
Add function to allow downloading a cert from the server

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -49,10 +49,10 @@ type ManagedIdentityConfig struct {
 }
 
 type LoginConfig struct {
-	Name        string
-	Token       string
-	Certificate string
-	CACertHash  string
+	Name        string `json:"name,omitempty"`
+	Token       string `json:"token,omitempty"`
+	Certificate string `json:"certificate,omitempty"`
+	CACertHash  string `json:"cacerthash,omitempty"`
 }
 
 func (ba *BearerAuthorizer) WithRPCAuthorization() credentials.PerRPCCredentials {


### PR DESCRIPTION
This function allows a caller to call a https endpoint, consult with a hashed version of the server certificate and then if valid, retrieve the server certificate from the endpoint.

This allows for a caller to get a trusted full certificate from just having the hash.