### PR TITLE
Verify function to accept raw certs 

### DIFF
--- a/pkg/certs/certificateAuthority.go
+++ b/pkg/certs/certificateAuthority.go
@@ -101,14 +101,14 @@ func NewCertificateAuthority(config *CAConfig) (*CertificateAuthority, error) {
 	return &ca, nil
 }
 
-// VerifyClientCertificate verifies certPems using the CertificateAuthority
-func (ca *CertificateAuthority) VerifyClientCertificate(certsPems [][]byte) error {
-	if len(certsPems) == 0 {
+// VerifyClientCertificate verifies rawCerts(ASN encoded) using the CertificateAuthority
+func (ca *CertificateAuthority) VerifyClientCertificate(rawCerts [][]byte) error {
+	if len(rawCerts) == 0 {
 		return errors.Wrapf(errors.InvalidInput, "Certificate list empty, nothing to verify")
 	}
 	certs := []*x509.Certificate{}
-	for _, rawcert := range certsPems {
-		cert, err := DecodeCertPEM(rawcert)
+	for _, rawcert := range rawCerts {
+		cert, err := x509.ParseCertificate(rawcert)
 		if err != nil {
 			return err
 		}

--- a/pkg/certs/certs_test.go
+++ b/pkg/certs/certs_test.go
@@ -153,7 +153,7 @@ func Test_CACertsVerify(t *testing.T) {
 		t.Errorf("Found certDER or renewCount Extensions")
 	}
 
-	clientCerts := [][]byte{clientCertPem}
+	clientCerts := [][]byte{clientCert.Raw}
 
 	if err := caAuth.VerifyClientCertificate(clientCerts); err != nil {
 		panic("failed to verify certificate: " + err.Error())
@@ -216,7 +216,7 @@ func Test_CACertsRenewVerify(t *testing.T) {
 		t.Errorf("Invalid certificate expiry")
 	}
 
-	clientCerts := [][]byte{clientCertPem}
+	clientCerts := [][]byte{clientCert.Raw}
 
 	if err := caAuth.VerifyClientCertificate(clientCerts); err != nil {
 		panic("failed to verify certificate: " + err.Error())
@@ -237,7 +237,7 @@ func Test_CACertsRenewVerify(t *testing.T) {
 		t.Errorf("Failed Decoding privatekey: %s", err.Error())
 	}
 	signConf = SignConfig{Offset: time.Second * 20}
-	certClient1Pem, err := caAuth.SignRequest(csr1, clientCertPem, &signConf)
+	certClient1Pem, err := caAuth.SignRequest(csr1, clientCert.Raw, &signConf)
 	if err != nil {
 		t.Errorf("Error signing CSR: %s", err.Error())
 	}
@@ -278,7 +278,7 @@ func Test_CACertsRenewVerify(t *testing.T) {
 		t.Errorf("Extension renew count is wrong")
 	}
 
-	clientCerts = [][]byte{certClient1Pem}
+	clientCerts = [][]byte{certClient1.Raw}
 	if err := caAuth.VerifyClientCertificate(clientCerts); err != nil {
 		t.Errorf("failed to verify certificate: " + err.Error())
 	}
@@ -299,7 +299,7 @@ func Test_CACertsRenewVerify(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed Decoding privatekey: %s", err.Error())
 	}
-	certClient2Pem, err := caAuth.SignRequest(csr2, certClient1Pem, nil)
+	certClient2Pem, err := caAuth.SignRequest(csr2, certClient1.Raw, nil)
 	if err != nil {
 		t.Errorf("Error signing CSR: %s", err.Error())
 	}
@@ -337,7 +337,7 @@ func Test_CACertsRenewVerify(t *testing.T) {
 		t.Errorf("Extension renew count is wrong")
 	}
 
-	clientCerts = [][]byte{certClient2Pem}
+	clientCerts = [][]byte{certClient2.Raw}
 	if err := caAuth.VerifyClientCertificate(clientCerts); err != nil {
 		t.Errorf("failed to verify certificate: " + err.Error())
 	}
@@ -394,7 +394,7 @@ func Test_CACertsRenewVerifySameKey(t *testing.T) {
 		t.Errorf("Invalid certificate expiry")
 	}
 
-	clientCerts := [][]byte{clientCertPem}
+	clientCerts := [][]byte{clientCert.Raw}
 
 	if err := caAuth.VerifyClientCertificate(clientCerts); err != nil {
 		panic("failed to verify certificate: " + err.Error())
@@ -409,7 +409,7 @@ func Test_CACertsRenewVerifySameKey(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error creating renew CSR: %s", err.Error())
 	}
-	certClient1Pem, err := caAuth.SignRequest(csr1, clientCertPem, nil)
+	certClient1Pem, err := caAuth.SignRequest(csr1, clientCert.Raw, nil)
 	if err != nil {
 		t.Errorf("Error signing CSR: %s", err.Error())
 	}
@@ -450,7 +450,7 @@ func Test_CACertsRenewVerifySameKey(t *testing.T) {
 		t.Errorf("Extension renew count is wrong")
 	}
 
-	clientCerts = [][]byte{certClient1Pem}
+	clientCerts = [][]byte{certClient1.Raw}
 	if err := caAuth.VerifyClientCertificate(clientCerts); err != nil {
 		t.Errorf("failed to verify certificate: " + err.Error())
 	}
@@ -467,7 +467,7 @@ func Test_CACertsRenewVerifySameKey(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error creating renew CSR: %s", err.Error())
 	}
-	certClient2Pem, err := caAuth.SignRequest(csr2, certClient1Pem, nil)
+	certClient2Pem, err := caAuth.SignRequest(csr2, certClient1.Raw, nil)
 	if err != nil {
 		t.Errorf("Error signing CSR: %s", err.Error())
 	}
@@ -506,7 +506,7 @@ func Test_CACertsRenewVerifySameKey(t *testing.T) {
 		t.Errorf("Extension renew count is wrong")
 	}
 
-	clientCerts = [][]byte{certClient2Pem}
+	clientCerts = [][]byte{certClient2.Raw}
 	if err := caAuth.VerifyClientCertificate(clientCerts); err != nil {
 		t.Errorf("failed to verify certificate: " + err.Error())
 	}


### PR DESCRIPTION
Verify function to accept raw certs rather than encoded certs to avoid cost of conversion during verification