### PR TITLE
Add ProviderID helpers, including support for BareMetal.

### DIFF
--- a/pkg/providerid/providerid.go
+++ b/pkg/providerid/providerid.go
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache v2.0 license.
+
+package providerid
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	ProviderName     string = "moc"
+	ProviderIDPrefix string = ProviderName + "://"
+)
+
+type HostType string
+
+const (
+	HostTypeVM        HostType = "vm"
+	HostTypeBareMetal HostType = "baremetal"
+)
+
+func FormatInstanceID(hostType HostType, machineName string) string {
+	switch hostType {
+	case HostTypeVM:
+		// Don't append the host type for VMs to maintain consistency with previous versions.
+		return machineName
+
+	default:
+		return string(hostType) + "/" + machineName
+	}
+}
+
+func FormatProviderID(hostType HostType, machineName string) string {
+	return ProviderIDPrefix + FormatInstanceID(hostType, machineName)
+}
+
+func ParseProviderID(providerID string) (HostType, string, error) {
+	if providerID == "" {
+		return "", "", fmt.Errorf("providerID is empty")
+	}
+
+	withoutPrefix := strings.TrimPrefix(providerID, ProviderIDPrefix)
+	if withoutPrefix == providerID {
+		return "", "", fmt.Errorf("providerID is missing expected prefix (%s): %s", ProviderIDPrefix, providerID)
+	}
+
+	withoutPrefix = strings.TrimSpace(withoutPrefix)
+
+	// Parse out the host type.
+	split := strings.SplitN(withoutPrefix, "/", 2)
+	if len(split) < 1 {
+		return "", "", fmt.Errorf("providerID is invalid")
+	}
+
+	if len(split) == 1 {
+		// VMs don't have the host type prefix.
+		return HostTypeVM, split[0], nil
+	}
+
+	hostType := HostType(split[0])
+	machineName := split[1]
+
+	if hostType != HostTypeBareMetal {
+		return "", "", fmt.Errorf("providerID contains unknown host type: %s", string(hostType))
+	}
+
+	return hostType, machineName, nil
+}


### PR DESCRIPTION
Add helper functions for handling ProviderID. This ensures that
the ProviderID handling logic is shared for all the components
that interact with MOC ProviderIDs.

In addition, give bare-metal machines their own unique namespace
in the ProviderID ("moc://baremetal/<machine-name>") to ensure
their can't be any name conflicts.