### PR TITLE
Fix the condition for validating if an IP range is within subnet CIDR

### DIFF
--- a/pkg/net/net.go
+++ b/pkg/net/net.go
@@ -231,7 +231,7 @@ func RangesOverlap(range1start, range1end, range2start, range2end net.IP) bool {
 }
 
 func IsRangeInCIDR(start, end net.IP, cidr *net.IPNet) bool {
-	if cidr.Contains(start) || cidr.Contains(end) {
+	if cidr.Contains(start) && cidr.Contains(end) {
 		return true
 	}
 	return false

--- a/pkg/net/net_test.go
+++ b/pkg/net/net_test.go
@@ -258,8 +258,8 @@ func Test_IsRangeInCIDR(t *testing.T) {
 	require.True(t, IsRangeInCIDR(net.ParseIP("10.0.0.250"), net.ParseIP("10.0.0.255"), cidr))
 	require.True(t, IsRangeInCIDR(net.ParseIP("10.0.0.0"), net.ParseIP("10.0.0.255"), cidr))
 
-	require.True(t, IsRangeInCIDR(net.ParseIP("9.0.0.0"), net.ParseIP("10.0.0.1"), cidr))
-	require.True(t, IsRangeInCIDR(net.ParseIP("10.0.0.254"), net.ParseIP("11.0.0.0"), cidr))
+	require.False(t, IsRangeInCIDR(net.ParseIP("9.0.0.0"), net.ParseIP("10.0.0.1"), cidr))
+	require.False(t, IsRangeInCIDR(net.ParseIP("10.0.0.254"), net.ParseIP("11.0.0.0"), cidr))
 
 	require.False(t, IsRangeInCIDR(net.ParseIP("9.0.0.0"), net.ParseIP("9.255.255.255"), cidr))
 	require.False(t, IsRangeInCIDR(net.ParseIP("10.0.1.0"), net.ParseIP("10.0.1.255"), cidr))


### PR DESCRIPTION
This PR is a fix for the bug: https://msazure.visualstudio.com/msk8s/_workitems/edit/19635560

Currently, when the user tries to create a virtualnetwork with either of the IP pool range outside the subnet CIDR, it succeeds. Ideally it should throw an error to the user that the passed IP address(start or end) is outside the range.

This validation has been fixed in this PR along with the relevant tests.