### PR TITLE
fix nil check while fixing bug: 29734266

### DIFF
--- a/pkg/redact/redact.go
+++ b/pkg/redact/redact.go
@@ -81,7 +81,7 @@ func RedactSensitiveError(msg interface{}, val reflect.Value, err *error) {
 // It takes a message of any type and a pointer to an error, and processes the message
 // to remove any sensitive data from error message.
 func RedactError(msg interface{}, err *error) {
-	if err != nil {
+	if err != nil && *err != nil {
 		RedactSensitiveError(msg, reflect.ValueOf(msg), err)
 	}
 }
@@ -211,7 +211,7 @@ func redactField(options *descriptorpb.FieldOptions, fieldVal reflect.Value, err
 		return false
 	}
 
-	if fieldVal.Kind() == reflect.String && errMessage != nil && fieldVal.String() != "" {
+	if fieldVal.Kind() == reflect.String && errMessage != nil && *errMessage != nil && fieldVal.String() != "" {
 		if extensionType == common.E_Sensitive {
 			redactSensitiveField(fieldVal.String(), errMessage)
 		} else if extensionType == common.E_Sensitivejson {
@@ -256,7 +256,7 @@ func redactErrorJsonSensitiveField(val reflect.Value, errMessage *error) {
 	for key := range jsonData {
 		// This can be extended to an array of sensitive keys if needed
 		if key == "private-key" {
-			if strVal, ok := jsonData[key].(string); ok && errMessage != nil && strVal != "" {
+			if strVal, ok := jsonData[key].(string); ok && errMessage != nil && *errMessage != nil && strVal != "" {
 				redactSensitiveField(strVal, errMessage)
 			}
 		}

--- a/pkg/redact/redact_test.go
+++ b/pkg/redact/redact_test.go
@@ -117,6 +117,50 @@ func TestRedactedError(t *testing.T) {
 
 	assert.Equal(t, err.Error(), "authentication failed for user testIdentity with password ** Redacted **")
 }
+
+func TestNegativeRedactedError(t *testing.T) {
+	// Mock security.Identity
+	id := security.Identity{
+		Name:          "testIdentity",
+		Id:            "123",
+		ResourceGroup: "testGroup",
+		Password:      "testPassword",
+		Token:         "testToken",
+		LocationName:  "testLocation",
+		Certificates: map[string]string{
+			"testKey1": "testVal1",
+			"testKey2": "testVal2",
+		},
+		TokenExpiry: 30,
+		ClientType:  common.ClientType_ADMIN,
+		Tags: &common.Tags{
+			Tags: []*common.Tag{
+				{
+					Key:   "testKey1",
+					Value: "testValue1",
+				},
+				{
+					Key:   "testKey2",
+					Value: "testValue2",
+				},
+			},
+		},
+	}
+
+	a := security.AuthenticationRequest{
+		Identity: &id,
+	}
+
+	// Call the RedactedError function
+	err := fmt.Errorf("authentication failed for user %s with password %s", id.Name, id.Password)
+	err1 := &err
+	*err1 = nil
+
+	RedactError(&a, err1)
+
+	assert.Equal(t, *err1, nil)
+}
+
 func TestRedactErrorJsonSensitiveField(t *testing.T) {
 	tests := []struct {
 		name          string


### PR DESCRIPTION
while fixing bug: 29734266 in previous commit, introduced a bug for nil check

Incorrect check
err != nil

corrected check
err != nil && *err != nil

previous PR: https://github.com/microsoft/moc/commit/02673a144d479a77a0e834026ca1475df5e124a8