### PR TITLE
cherry-pick - bug: 29734266 - GalleryImage SAS URI not redacted in Telemetry

### DIFF
--- a/pkg/redact/redact.go
+++ b/pkg/redact/redact.go
@@ -5,6 +5,7 @@ package redact
 
 import (
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"strings"
 
@@ -45,6 +46,43 @@ func Redact(msg interface{}, val reflect.Value) {
 		Redact(msg, val.Elem())
 	case reflect.Struct:
 		redactMessage(msg, val)
+	}
+}
+
+// RedactSensitiveError traverses the given value and processes fields marked as sensitive, redacting their data from error message.
+// Note: The function modifies the error message in place if sensitive data is found.
+func RedactSensitiveError(msg interface{}, val reflect.Value, err *error) {
+	// TODO: This needs to be optimized!
+	// Should cache messages that contain no sensitive data to ignore, and should cache the map of tag number to field name
+
+	if err == nil {
+		return
+	}
+
+	if !val.IsValid() {
+		return
+	}
+
+	switch val.Kind() {
+	case reflect.Slice:
+		for i := 0; i < val.Len(); i += 1 {
+			RedactSensitiveError(val.Index(i).Interface(), val.Index(i), err)
+		}
+	case reflect.Map:
+		// TODO: Implement map logic. Currently only certificates in identity use it, and are redacted
+	case reflect.Ptr:
+		RedactSensitiveError(msg, val.Elem(), err)
+	case reflect.Struct:
+		redactErrorMessage(msg, val, err)
+	}
+}
+
+// RedactError redacts sensitive information from the provided error message.
+// It takes a message of any type and a pointer to an error, and processes the message
+// to remove any sensitive data from error message.
+func RedactError(msg interface{}, err *error) {
+	if err != nil {
+		RedactSensitiveError(msg, reflect.ValueOf(msg), err)
 	}
 }
 
@@ -121,5 +159,106 @@ func redactJsonSensitiveField(val reflect.Value) {
 	redactedJson, err := json.Marshal(jsonData)
 	if err == nil {
 		val.SetString(string(redactedJson))
+	}
+}
+
+func redactErrorMessage(msg interface{}, val reflect.Value, errMessage *error) {
+	properties := proto.GetProperties(reflect.TypeOf(msg).Elem())
+	_, md := descriptor.ForMessage((msg).(descriptor.Message))
+
+	for _, field := range md.GetField() {
+		fieldVal := getFieldVal(properties, field, val)
+		if !fieldVal.IsValid() {
+			continue
+		}
+
+		if field.Options != nil {
+			if redactField(field.Options, fieldVal, errMessage, common.E_Sensitivejson) {
+				continue
+			}
+			if redactField(field.Options, fieldVal, errMessage, common.E_Sensitive) {
+				continue
+			}
+		}
+
+		if field.GetType() == descriptorpb.FieldDescriptorProto_TYPE_MESSAGE {
+			RedactSensitiveError(fieldVal.Interface(), reflect.ValueOf(fieldVal.Interface()), errMessage)
+		}
+	}
+}
+
+// getFieldVal retrieves the value of a specific field from a given struct based on the field's descriptor.
+// It searches through the properties of the struct and matches the field's tag number to return the corresponding value.
+// Returns:
+// - A reflect.Value representing the value of the specified field. If the field is not found, it returns an empty reflect.Value.
+func getFieldVal(properties *proto.StructProperties, field *descriptorpb.FieldDescriptorProto, val reflect.Value) reflect.Value {
+	for _, p := range properties.Prop {
+		if int32(p.Tag) == field.GetNumber() {
+			return val.FieldByName(p.Name)
+		}
+	}
+	for _, oot := range properties.OneofTypes {
+		if int32(oot.Prop.Tag) == field.GetNumber() {
+			return val.Field(oot.Field).Elem().FieldByName(oot.Prop.Name)
+		}
+	}
+	return reflect.Value{}
+}
+
+func redactField(options *descriptorpb.FieldOptions, fieldVal reflect.Value, errMessage *error, extensionType *proto.ExtensionDesc) bool {
+	ex, err := proto.GetExtension(options, extensionType)
+	if err == proto.ErrMissingExtension || err != nil || !*ex.(*bool) {
+		return false
+	}
+
+	if fieldVal.Kind() == reflect.String && errMessage != nil && fieldVal.String() != "" {
+		if extensionType == common.E_Sensitive {
+			redactSensitiveField(fieldVal.String(), errMessage)
+		} else if extensionType == common.E_Sensitivejson {
+			redactErrorJsonSensitiveField(fieldVal, errMessage)
+		}
+	}
+	return true
+}
+
+// redactSensitiveField redacts occurrences of a sensitive field value from an error message.
+// If the error message contains the sensitive field value, it replaces all instances of the field value
+// with a predefined redacted string and updates the error message.
+//
+// Parameters:
+//   - fieldVal: The sensitive field value to be redacted from the error message.
+//   - errMessage: A pointer to the error message that may contain the sensitive field value.
+//
+// Note: The function modifies the error message in place.
+func redactSensitiveField(fieldVal string, errMessage *error) {
+	errMsg := (*errMessage).Error()
+	if strings.Contains(errMsg, fieldVal) {
+		errMsg = strings.ReplaceAll(errMsg, fieldVal, RedactedString)
+		*errMessage = fmt.Errorf("%s", errMsg)
+	}
+}
+
+// redactErrorJsonSensitiveField redacts sensitive fields in a JSON string contained within a reflect.Value.
+// It specifically looks for the "private-key" field and redacts its value if found.
+// The function takes two parameters:
+// - val: a reflect.Value containing the JSON string to be processed.
+// - errMessage: a pointer to an error that will be updated if a sensitive field is redacted.
+//
+// The function first converts the JSON string to a map, then iterates over the keys to find the "private-key" field.
+// If the "private-key" field is found and contains a non-empty string, the redactSensitiveField function is called
+// to redact the value and update the errMessage.
+func redactErrorJsonSensitiveField(val reflect.Value, errMessage *error) {
+	var jsonData map[string]interface{}
+	validJsonString := strings.ReplaceAll(val.String(), `\`, `"`)
+	if err := json.Unmarshal([]byte(validJsonString), &jsonData); err != nil {
+		return
+	}
+	for key := range jsonData {
+		// This can be extended to an array of sensitive keys if needed
+		if key == "private-key" {
+			if strVal, ok := jsonData[key].(string); ok && errMessage != nil && strVal != "" {
+				redactSensitiveField(strVal, errMessage)
+			}
+		}
 	}
 }

--- a/pkg/redact/redact.go
+++ b/pkg/redact/redact.go
@@ -81,7 +81,7 @@ func RedactSensitiveError(msg interface{}, val reflect.Value, err *error) {
 // It takes a message of any type and a pointer to an error, and processes the message
 // to remove any sensitive data from error message.
 func RedactError(msg interface{}, err *error) {
-	if err != nil {
+	if err != nil && *err != nil {
 		RedactSensitiveError(msg, reflect.ValueOf(msg), err)
 	}
 }
@@ -211,7 +211,7 @@ func redactField(options *descriptorpb.FieldOptions, fieldVal reflect.Value, err
 		return false
 	}
 
-	if fieldVal.Kind() == reflect.String && errMessage != nil && fieldVal.String() != "" {
+	if fieldVal.Kind() == reflect.String && errMessage != nil && *errMessage != nil && fieldVal.String() != "" {
 		if extensionType == common.E_Sensitive {
 			redactSensitiveField(fieldVal.String(), errMessage)
 		} else if extensionType == common.E_Sensitivejson {
@@ -256,7 +256,7 @@ func redactErrorJsonSensitiveField(val reflect.Value, errMessage *error) {
 	for key := range jsonData {
 		// This can be extended to an array of sensitive keys if needed
 		if key == "private-key" {
-			if strVal, ok := jsonData[key].(string); ok && errMessage != nil && strVal != "" {
+			if strVal, ok := jsonData[key].(string); ok && errMessage != nil && *errMessage != nil && strVal != "" {
 				redactSensitiveField(strVal, errMessage)
 			}
 		}

--- a/pkg/redact/redact_test.go
+++ b/pkg/redact/redact_test.go
@@ -3,11 +3,14 @@
 package redact
 
 import (
+	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/microsoft/moc/rpc/cloudagent/security"
 	"github.com/microsoft/moc/rpc/common"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_RedactedMessage(t *testing.T) {
@@ -72,5 +75,77 @@ func Test_RedactedMessage(t *testing.T) {
 	redacted := (msg).(*security.AuthenticationRequest)
 	if !proto.Equal(proto.Message(expect), redacted) {
 		t.Errorf("Redacted AuthenticationRequest: {%v} does not match expected: {%v}", redacted, expectedAuthenticationRequest)
+	}
+}
+
+func TestRedactedError(t *testing.T) {
+	// Mock security.Identity
+	id := security.Identity{
+		Name:          "testIdentity",
+		Id:            "123",
+		ResourceGroup: "testGroup",
+		Password:      "testPassword",
+		Token:         "testToken",
+		LocationName:  "testLocation",
+		Certificates: map[string]string{
+			"testKey1": "testVal1",
+			"testKey2": "testVal2",
+		},
+		TokenExpiry: 30,
+		ClientType:  common.ClientType_ADMIN,
+		Tags: &common.Tags{
+			Tags: []*common.Tag{
+				{
+					Key:   "testKey1",
+					Value: "testValue1",
+				},
+				{
+					Key:   "testKey2",
+					Value: "testValue2",
+				},
+			},
+		},
+	}
+
+	a := security.AuthenticationRequest{
+		Identity: &id,
+	}
+
+	// Call the RedactedError function
+	err := fmt.Errorf("authentication failed for user %s with password %s", id.Name, id.Password)
+	RedactError(&a, &err)
+
+	assert.Equal(t, err.Error(), "authentication failed for user testIdentity with password ** Redacted **")
+}
+func TestRedactErrorJsonSensitiveField(t *testing.T) {
+	tests := []struct {
+		name          string
+		inputJson     string
+		inputError    string
+		expectedError string
+	}{
+		{
+			name:          "Redact private-key in JSON",
+			inputJson:     `{"private-key": "sensitiveKey", "other-key": "othervalue"}`,
+			inputError:    "error with sensitiveKey",
+			expectedError: "error with ** Redacted **",
+		},
+		{
+			name:          "No private-key in JSON",
+			inputJson:     `{"other-key": "otherValue"}`,
+			inputError:    "error with no sensitive data",
+			expectedError: "error with no sensitive data",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			val := reflect.ValueOf(tt.inputJson)
+			err := fmt.Errorf(tt.inputError)
+
+			redactErrorJsonSensitiveField(val, &err)
+
+			assert.Equal(t, fmt.Errorf(tt.expectedError), err)
+		})
 	}
 }

--- a/pkg/redact/redact_test.go
+++ b/pkg/redact/redact_test.go
@@ -117,6 +117,50 @@ func TestRedactedError(t *testing.T) {
 
 	assert.Equal(t, err.Error(), "authentication failed for user testIdentity with password ** Redacted **")
 }
+
+func TestNegativeRedactedError(t *testing.T) {
+	// Mock security.Identity
+	id := security.Identity{
+		Name:          "testIdentity",
+		Id:            "123",
+		ResourceGroup: "testGroup",
+		Password:      "testPassword",
+		Token:         "testToken",
+		LocationName:  "testLocation",
+		Certificates: map[string]string{
+			"testKey1": "testVal1",
+			"testKey2": "testVal2",
+		},
+		TokenExpiry: 30,
+		ClientType:  common.ClientType_ADMIN,
+		Tags: &common.Tags{
+			Tags: []*common.Tag{
+				{
+					Key:   "testKey1",
+					Value: "testValue1",
+				},
+				{
+					Key:   "testKey2",
+					Value: "testValue2",
+				},
+			},
+		},
+	}
+
+	a := security.AuthenticationRequest{
+		Identity: &id,
+	}
+
+	// Call the RedactedError function
+	err := fmt.Errorf("authentication failed for user %s with password %s", id.Name, id.Password)
+	err1 := &err
+	*err1 = nil
+
+	RedactError(&a, err1)
+
+	assert.Equal(t, *err1, nil)
+}
+
 func TestRedactErrorJsonSensitiveField(t *testing.T) {
 	tests := []struct {
 		name          string


### PR DESCRIPTION
cherry-pick - moc repo - redact error - bug: 29734266 - GalleryImage SAS URI not redacted in Telemetry.

Customer's failed galleryimage creation errored out initially at the node agent level, which should have redacted when showing the error message.

The redaction however is not redacting the error message at the node agent level because current redaction only operates on the virtualharddisk properties that are marked as sensitive in the protobufs. The proxy error however, is a common container error that prints out the uri proxy by default; the error message itself does not go through any redacting. causing the SAS URI to propogate (as part of the error message) all the way up to the azstackhci-operator level: