### PR TITLE
[moc] Adding ChmodRecursivelyAdmin only function

### DIFF
--- a/pkg/fs/fs_darwin.go
+++ b/pkg/fs/fs_darwin.go
@@ -4,8 +4,26 @@ package fs
 
 import (
 	"os"
+	"path/filepath"
 )
 
 func Chmod(path string, mode os.FileMode) error {
 	return os.Chmod(path, mode)
+}
+
+func ChmodRecursiveAdmin(path string) error {
+	err := filepath.Walk(path, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+
+		if walkErr = Chmod(path, 0700); walkErr != nil {
+			return walkErr
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/pkg/fs/fs_linux.go
+++ b/pkg/fs/fs_linux.go
@@ -4,8 +4,26 @@ package fs
 
 import (
 	"os"
+	"path/filepath"
 )
 
 func Chmod(path string, mode os.FileMode) error {
 	return os.Chmod(path, mode)
+}
+
+func ChmodRecursiveAdmin(path string) error {
+	err := filepath.Walk(path, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+
+		if walkErr = Chmod(path, 0700); walkErr != nil {
+			return walkErr
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/pkg/fs/fs_windows.go
+++ b/pkg/fs/fs_windows.go
@@ -4,10 +4,28 @@ package fs
 
 import (
 	"os"
+	"os/exec"
 
 	"github.com/hectane/go-acl"
 )
 
 func Chmod(path string, mode os.FileMode) error {
 	return acl.Chmod(path, mode)
+}
+
+func ChmodRecursiveAdmin(path string) error {
+	// Step1: Remove inhereted permissions
+	cmd := exec.Command("icacls", path, "/inheritance:r")
+	_, err := cmd.CombinedOutput()
+	if err != nil {
+		return err
+	}
+
+	// Step2: Grant admin permission to the directory
+	cmd = exec.Command("icacls", path, "/grant", "BUILTIN\\Administrators:(OI)(CI)(F)")
+	_, err = cmd.CombinedOutput()
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/pkg/fs/fs_windows.go
+++ b/pkg/fs/fs_windows.go
@@ -5,8 +5,10 @@ package fs
 import (
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/hectane/go-acl"
+	"github.com/microsoft/moc/pkg/errors"
 )
 
 func Chmod(path string, mode os.FileMode) error {
@@ -14,14 +16,21 @@ func Chmod(path string, mode os.FileMode) error {
 }
 
 func ChmodRecursiveAdmin(path string) error {
-	// Step1: Remove inhereted permissions
+	// Step 0: check for command injections because we using exec command to run icacls
+	var err error
+	if strings.Contains(path, "&") || strings.Contains(path, "|") || strings.Contains(path, ";") {
+		err = errors.Wrapf(errors.InvalidInput, "Path [%s] contains invalid operators like '&', '|', ';'", path)
+		return err
+	}
+
+	// Step 1: Remove inhereted permissions
 	cmd := exec.Command("icacls", path, "/inheritance:r")
-	_, err := cmd.CombinedOutput()
+	_, err = cmd.CombinedOutput()
 	if err != nil {
 		return err
 	}
 
-	// Step2: Grant admin permission to the directory
+	// Step 2: Grant admin permission to the directory
 	cmd = exec.Command("icacls", path, "/grant", "BUILTIN\\Administrators:(OI)(CI)(F)")
 	_, err = cmd.CombinedOutput()
 	if err != nil {

--- a/pkg/fs/fs_windows.go
+++ b/pkg/fs/fs_windows.go
@@ -18,8 +18,8 @@ func Chmod(path string, mode os.FileMode) error {
 func ChmodRecursiveAdmin(path string) error {
 	// Step 0: check for command injections because we using exec command to run icacls
 	var err error
-	if strings.Contains(path, "&") || strings.Contains(path, "|") || strings.Contains(path, ";") {
-		err = errors.Wrapf(errors.InvalidInput, "Path [%s] contains invalid operators like '&', '|', ';'", path)
+	if strings.Contains(path, "&") || strings.Contains(path, "|") || strings.Contains(path, ";") || strings.Contains(path, "^") || strings.Contains(path, ">") {
+		err = errors.Wrapf(errors.InvalidInput, "Path [%s] contains invalid operators like '&', '|', ';', '^', '>'", path)
 		return err
 	}
 


### PR DESCRIPTION
Added ChmodRecursivelyAdmin function for `windows`, `linux`, and `darwin`. 
For **Windows** it will set the directory to be `BUILTIN\Adminstrators` access only and grant it `(OI)(CI)(F)`
For **Linux** and **Darwin**, it will recursively grant all the subdirectories and folders to have `0700` file permission. 