### PR TITLE
fix bug in redact sensitivejson

### DIFF
--- a/pkg/redact/redact.go
+++ b/pkg/redact/redact.go
@@ -148,8 +148,7 @@ func redactMessage(msg interface{}, val reflect.Value) {
 
 func redactJsonSensitiveField(val reflect.Value) {
 	var jsonData map[string]interface{}
-	validJsonString := strings.ReplaceAll(val.String(), `\`, `"`)
-	if err := json.Unmarshal([]byte(validJsonString), &jsonData); err != nil {
+	if err := json.Unmarshal([]byte(val.String()), &jsonData); err != nil {
 		return
 	}
 
@@ -254,8 +253,7 @@ func redactSensitiveField(fieldVal string, errMessage *error) {
 // to redact the value and update the errMessage.
 func redactErrorJsonSensitiveField(val reflect.Value, errMessage *error) {
 	var jsonData map[string]interface{}
-	validJsonString := strings.ReplaceAll(val.String(), `\`, `"`)
-	if err := json.Unmarshal([]byte(validJsonString), &jsonData); err != nil {
+	if err := json.Unmarshal([]byte(val.String()), &jsonData); err != nil {
 		return
 	}
 	sensitiveKeys := [...]string{"private-key", "sasURI"}


### PR DESCRIPTION
Testing done

RunCommandInputParameters
*********************************
Source:<CommandID:\"InstallArcAgent\" > RunCommandInputParameters:<Name:\"AgentConfig\" Value:\"{\\\"cloud\\\":\\\"AzureCloud\\\",\\\"correlation-id\\\":\\\"cd1f3bcd-78fa-4494-a4a6-83d280ae4ff9\\\",\\\"endpoint-resource-manager\\\":\\\"\\\",\\\"kind\\\":\\\"HCI\\\",\\\"location\\\":\\\"eastus\\\",\\\"msi-cert-retries\\\":26,\\\"private-key\\\":\\\"** Redacted **\\\",\\\" ......
 
Sas Uri - Sensitive JSON
******************************
{"verbositylevel":0,"name":"VirtualHardDisk Create name:\"mylocal-storacctimage6\" source:\"{\\\"sasURI\\\":\\\"** Redacted **\\\"}\" path:\"** Redacted **\" containerName:\"UserStorage3-a103d77be3d740f99937b2132c7f6679-17ee8ecb-b995-4a26-b4d5-c281538f9a99-edgeci-registration-hc1s46r0306-p7qxk8oz\" entity:<> tags:<> sourceType:HTTP_SOURCE TargetUrl:\"** Redacted **\" ","traceid":"a3e7071f4c416fcaf0db1c6882a62e9f","id":"3c9d59d94c501aa5","parentid":"3794063c428f2876","starttime":"2025-02-03T03:35:19.971102Z","endtime":"2025-02-03T03:35:20.379882Z","duration":"0.41s","entity":"","Annotations":null,"Attributes":[{"Key":"correlationId","Value":{"Type":"STRING","Value":"69323e1c-2f01-4c7f-a269-d4553c24d889"}},{"Key":"verbositylevel","Value":{"Type":"INT64","Value":0}}],"Events":[{"Name":"*storage.VirtualHardDisk SetProvisionStatus [CREATING]","Attributes":[{"Key":"CallerLocation","Value":{"Type":"STRING","Value":"internal.go:165 "}}],"DroppedAttributeCount":0,"Time":"2025-02-03T03:35:19.976414Z"},{"Name":"HCS Call: CreateVirtualHardDisk mylocal-storacctimage6","Attributes":[{"Key":"CallerLocation","Value":{"Type":"STRING","Value":"hcs.go:64 "}}],"DroppedAttributeCount":0,"Time":"2025-02-03T03:35:19.9788953Z"},{"Name":"HCS Call: DownloadSource - GetImageFromAzureHTTP","Attributes":[{"Key":"CallerLocation","Value":{"Type":"STRING","Value":"httpSource.go:20 "}}],"DroppedAttributeCount":0,"Time":"2025-02-03T03:35:19.9799977Z"},{"Name":"HCS Call: CreateVirtualHardDisk mylocal-storacctimage6","Attributes":[{"Key":"CallerLocation","Value":{"Type":"STRING","Value":"hcs.go:102 
 