### PR TITLE
Add NO_KEY_WRAP type to key wrapping algorithm

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/microsoft/moc
 
-go 1.22
+go 1.23.0
+
+toolchain go1.24.1
 
 require (
 	github.com/golang-jwt/jwt v3.2.2+incompatible
@@ -18,11 +20,11 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/net v0.34.0 // indirect
-	golang.org/x/sys v0.29.0 // indirect
-	golang.org/x/text v0.21.0 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20250127172529-29210b9bc287 // indirect
-	google.golang.org/protobuf v1.36.4 // indirect
+	golang.org/x/net v0.37.0 // indirect
+	golang.org/x/sys v0.31.0 // indirect
+	golang.org/x/text v0.23.0 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20250324211829-b45e905df463 // indirect
+	google.golang.org/protobuf v1.36.6 // indirect
 )
 
 replace (

--- a/rpc/common/moc_common_security.proto
+++ b/rpc/common/moc_common_security.proto
@@ -79,6 +79,7 @@ enum KeyWrappingAlgorithm {
 	CKM_RSA_AES_KEY_WRAP = 0;
 	RSA_AES_KEY_WRAP_256 = 1;
 	RSA_AES_KEY_WRAP_384 = 2;
+	NO_KEY_WRAP = 3;
 }
 
 message Scope {


### PR DESCRIPTION
This is the 1st PR of below work item "Import private key in plain text":
https://msazure.visualstudio.com/One/_workitems/edit/31918085

NO_KEY_WRAP is already available in moc-sdk-for-go. For this work item, I'm using NO_KEY_WRAP to identify when to import a plaintext key