### PR TITLE
adding tags to security rule

### DIFF
--- a/rpc/cloudagent/network/networksecuritygroup/moc_cloudagent_networksecuritygroup.proto
+++ b/rpc/cloudagent/network/networksecuritygroup/moc_cloudagent_networksecuritygroup.proto
@@ -55,6 +55,7 @@ message NetworkSecurityGroupRule {
 	uint32 priority = 10;
 	bool logging = 11;
 	bool isDefaultRule = 12;
+	Tags tags = 13;
 }
 
 message NetworkSecurityGroup {


### PR DESCRIPTION
adding tags to security rule for storing the unique security rule name (azstackhci operator name) just like any other resource.