### PR TITLE
Update GetTransportCredentials to include NextProtos

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -206,6 +206,7 @@ func NewTransportCredentialFromAccessFile(serverName string, accessFile WssdConf
 func (transportCredentials *TransportCredentialsProvider) GetTransportCredentials() credentials.TransportCredentials {
 	creds := &tls.Config{
 		ServerName: transportCredentials.serverName,
+		NextProtos: []string{"h2"},
 	}
 	if len(transportCredentials.certificate) > 0 {
 		creds.Certificates = transportCredentials.certificate


### PR DESCRIPTION
If you upgraded from a grpc-go version earlier than 1.67, your TLS connections may have stopped working due to ALPN enforcement. Add NextProtos: []string{"h2"} to the tls.Config in GetTransportCredentials to ensure that the connection uses HTTP/2.