### PR TITLE
query group name from SID

### DIFF
--- a/pkg/fs/fs_windows.go
+++ b/pkg/fs/fs_windows.go
@@ -33,11 +33,11 @@ func ChmodRecursiveAdmin(path string) error {
 
 	// Step 2: Grant admin permission to the directory
 	getBuiltInAdminGroupName := `function Get-BuiltInAdminName {
-    param()
-    $obj = New-Object System.Security.Principal.SecurityIdentifier("S-1-5-32-544")
+	param()
+	$obj = New-Object System.Security.Principal.SecurityIdentifier("S-1-5-32-544")
 	$name = ($obj.Translate([System.Security.Principal.NTAccount])).Value
 	"$name"
-    }
+	}
 `
 	builtInAdminGroupName, err := powershell.ExecutePowershell(getBuiltInAdminGroupName, `Get-BuiltInAdminName`)
 	builtInAdminGroupNamePermissions := strings.TrimSpace(builtInAdminGroupName) + ":(OI)(CI)(F)"

--- a/pkg/fs/fs_windows.go
+++ b/pkg/fs/fs_windows.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/hectane/go-acl"
+	"github.com/microsoft/moc-pkg/pkg/powershell"
 	"github.com/microsoft/moc/pkg/errors"
 )
 
@@ -31,7 +32,17 @@ func ChmodRecursiveAdmin(path string) error {
 	}
 
 	// Step 2: Grant admin permission to the directory
-	cmd = exec.Command("icacls", path, "/grant", "BUILTIN\\Administrators:(OI)(CI)(F)")
+	getBuiltInAdminGroupName := `function Get-BuiltInAdminName {
+    param()
+    $obj = New-Object System.Security.Principal.SecurityIdentifier("S-1-5-32-544")
+	$name = ($obj.Translate([System.Security.Principal.NTAccount])).Value
+	"$name"
+    }
+`
+	builtInAdminGroupName, err := powershell.ExecutePowershell(getBuiltInAdminGroupName, `Get-BuiltInAdminName`)
+	builtInAdminGroupNamePermissions := strings.TrimSpace(builtInAdminGroupName) + ":(OI)(CI)(F)"
+
+	cmd = exec.Command("icacls", path, "/grant", builtInAdminGroupNamePermissions)
 	_, err = cmd.CombinedOutput()
 	if err != nil {
 		return err


### PR DESCRIPTION
Built-in User/GroupName is not language agnostic. Using hardcoded name's cause "storage container create" to fail since "BUILTIN\Administrators" is not a valid name for (some) non-English OS installation.

<img width="1084" height="598" alt="image" src="https://github.com/user-attachments/assets/0395be4f-70a1-4a4a-a797-22d161fbc65e" />
