### PR TITLE
fix: add nil guards to prevent panic in tags package

### DIFF
--- a/pkg/tags/tags.go
+++ b/pkg/tags/tags.go
@@ -17,11 +17,17 @@ func InitTag(key, value string) *common.Tag {
 
 // AddTag
 func AddTag(key, value string, tags *common.Tags) {
+	if tags == nil {
+		return
+	}
 	tags.Tags = append(tags.GetTags(), InitTag(key, value))
 }
 
 // DeleteTag
 func DeleteTag(key string, tags *common.Tags) {
+	if tags == nil {
+		return
+	}
 	index := -1
 	tagsList := tags.GetTags()
 	for idx, tag := range tagsList {
@@ -49,6 +55,9 @@ func GetTagValue(key string, tags *common.Tags) (string, error) {
 
 // AddTagValue
 func AddTagValue(key, value string, tags *common.Tags) {
+	if tags == nil {
+		return
+	}
 	for _, tag := range tags.GetTags() {
 		if tag.GetKey() == key {
 			tag.Value = value

--- a/pkg/tags/tags_test.go
+++ b/pkg/tags/tags_test.go
@@ -102,6 +102,32 @@ func TestAddTagValue(t *testing.T) {
 	t.Logf("%s", value)
 }
 
+func TestAddTagNilTags(t *testing.T) {
+	// Verify AddTag does not panic when tags is nil
+	AddTag("testkey", "testvalue", nil)
+}
+
+func TestAddTagValueNilTags(t *testing.T) {
+	// Verify AddTagValue does not panic when tags is nil
+	AddTagValue("testkey", "testvalue", nil)
+}
+
+func TestDeleteTagNilTags(t *testing.T) {
+	// Verify DeleteTag does not panic when tags is nil
+	DeleteTag("testkey", nil)
+}
+
+func TestGetTagValueNilTags(t *testing.T) {
+	// GetTagValue should return NotFound for nil tags
+	_, err := GetTagValue("testkey", nil)
+	if err == nil {
+		t.Errorf("Expected error for nil tags")
+	}
+	if !errors.IsNotFound(err) {
+		t.Errorf("Expected NotFound error for nil tags")
+	}
+}
+
 func TestProtoToMap(t *testing.T) {
 	tags := &common.Tags{}
 	AddTagValue("testkey", "testvalue", tags)


### PR DESCRIPTION
## Summary

AddTag, AddTagValue, and DeleteTag all dereference the tags pointer without checking for nil. When callers pass nil \*common.Tags\ (e.g., \wssdcloudagent/virtualmachineimage/client.go:953\ during VM Create), the functions panic with nil pointer dereference.

## Telemetry Evidence

Production telemetry from \HostOsPanicLogs\ (30-day window) shows **4 panics at \	ags.go:58\ (AddTagValue) across 2 devices**.

Stack trace:
\\\
tags.AddTagValue (tags.go:58)
  ← virtualmachineimage.client.go:953
    ← virtualmachine.client.go:2029
      ← VirtualMachineAgent_Invoke_Handler (VM Create)
\\\

## Changes

- Add nil guard at the top of \AddTag\, \AddTagValue\, and \DeleteTag\
- \GetTagValue\ already handles nil safely via \GetTags()\ proto accessor
- Added 4 unit tests for nil safety (all functions)

## Testing

- All existing tests pass (\go test ./pkg/tags/ -v\)
- 4 new tests verify nil safety for AddTag, AddTagValue, DeleteTag, GetTagValue

## Engineering Checklist Status
| Step | Status | Notes |
|------|--------|-------|
| 1. Plan | ✅ | Telemetry-driven investigation |
| 2. Corner Cases | ✅ | Nil tags is the corner case being fixed |
| 3. Error Handling | ✅ | Graceful no-op on nil |
| 4. Error Codes | N/A | No error codes involved |
| 5. Telemetry | ✅ | Verified via HostOsPanicLogs |
| 6. Test Cases | ✅ | 4 new tests added |
| 7. Pipeline Validation | 🔄 | Awaiting CICD |
| 8. Green PR | 🔄 | In progress |
| 9. Feature Flag | N/A | Bug fix |
| 10. Data-Driven Enablement | N/A | Bug fix |