### PR TITLE
[cherry-pick] chore: update Go to 1.26.0

### DIFF
--- a/.pipelines/build.yaml
+++ b/.pipelines/build.yaml
@@ -18,7 +18,7 @@ jobs:
   steps:
   - task: GoTool@0
     inputs:
-      version: '1.25.3'
+      version: '1.26'
   - task: InstallSSHKey@0
     inputs:
       knownHostsEntry: '$(KNOWN_HOST)' 
@@ -78,7 +78,7 @@ jobs:
   steps:
   - task: GoTool@0
     inputs:
-      version: '1.25.3'
+      version: '1.26'
 
   - script: |
       make golangci-lint

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ all: format test
 
 .PHONY: tidy
 tidy:
-	go mod tidy
+	-go mod tidy -e
 
 format:
 	gofmt -s -w rpc/ pkg/ 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/microsoft/moc
 
-go 1.25.0
+go 1.26
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
Cherry-picking https://github.com/microsoft/moc/pull/418

Update go.mod and pipeline YAML to Go 1.26.0.