### PR TITLE
pin gRPC version for build inmarket component

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ format:
 	gofmt -s -w rpc/ pkg/ 
 
 bootstrap:
-	GOOS="linux" go get -u google.golang.org/grpc@v1.59.0
+	GOOS="linux" go get google.golang.org/grpc@v1.59.0
 	GOOS="linux" go install github.com/golang/protobuf/protoc-gen-go@v1.3.2
 
 test: unittest


### PR DESCRIPTION
"go get -u google.golang.org/grpc@v1.59.0" updates grpc to v1.59.0 AND updates
all transitive dependencies to their latest versions. It would cause error like "go: golang.org/x/net@v0.51.0 requires go >= 1.25.0 (running go 1.24.3)"

The workaround to continue building MOC with go 1.24.3 is to remove -u parameter. MOCBuild-pullrequest shows removing -u works in build.