### PR TITLE
Makefile: drop stale grpc@v1.59.0 pin from bootstrap target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,6 @@ format:
 	gofmt -s -w rpc/ pkg/ 
 
 bootstrap:
-	GOOS="linux" go get -u google.golang.org/grpc@v1.59.0
 	GOOS="linux" go install github.com/golang/protobuf/protoc-gen-go@v1.3.2
 
 test: unittest


### PR DESCRIPTION
## What

Remove the stale `go get -u google.golang.org/grpc@v1.59.0` line from the `bootstrap` target in the Makefile.

## Why

- `bootstrap` is a prerequisite of the `generate` and `pipeline` targets.
- The line pins grpc to **v1.59.0**, added in #367 when grpc was at v1.59.0, and never updated after `go.mod` moved to **v1.82.1**.
- Running `make generate` / `make pipeline` therefore **downgrades** the module's grpc back to v1.59.0 — re-introducing already-remediated CVEs — and `gen.sh`'s trailing `go mod tidy` persists that downgrade into `go.mod` / `go.sum`.

## Why removal is safe

- Proto generation does **not** need the grpc module fetched: `rpc/gen_proto.sh` generates via `--go_out=plugins=grpc:`, whose grpc plugin ships inside `protoc-gen-go@v1.3.2` (installed by the same `bootstrap` target).
- The grpc runtime version is governed entirely by `go.mod`. After this change, `bootstrap` installs only `protoc-gen-go` and grpc stays at the go.mod-selected **v1.82.1**.
- Sibling repos (moc-pkg, moc-sdk-for-go) carry no such grpc pin.

## Diff

```diff
 bootstrap:
-	GOOS="linux" go get -u google.golang.org/grpc@v1.59.0
 	GOOS="linux" go install github.com/golang/protobuf/protoc-gen-go@v1.3.2
```
